### PR TITLE
Reduce build warnings to minimum

### DIFF
--- a/ast/pom.xml
+++ b/ast/pom.xml
@@ -4,7 +4,6 @@
     <groupId>org.opencypher</groupId>
     <artifactId>front-end-parent</artifactId>
     <version>1.0.0-SNAPSHOT</version>
-    <relativePath>../</relativePath>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>
@@ -35,6 +34,15 @@
 
   <build>
     <plugins>
+      <plugin>
+        <groupId>net.alchim31.maven</groupId>
+        <artifactId>scala-maven-plugin</artifactId>
+        <configuration>
+          <args combine.children="append">
+            <arg>-language:implicitConversions</arg>
+          </args>
+        </configuration>
+      </plugin>
       <plugin>
         <groupId>org.scalastyle</groupId>
         <artifactId>scalastyle-maven-plugin</artifactId>

--- a/expressions/pom.xml
+++ b/expressions/pom.xml
@@ -4,7 +4,6 @@
     <groupId>org.opencypher</groupId>
     <artifactId>front-end-parent</artifactId>
     <version>1.0.0-SNAPSHOT</version>
-    <relativePath>../</relativePath>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/frontend/pom.xml
+++ b/frontend/pom.xml
@@ -4,7 +4,6 @@
     <groupId>org.opencypher</groupId>
     <artifactId>front-end-parent</artifactId>
     <version>1.0.0-SNAPSHOT</version>
-    <relativePath>../</relativePath>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/parser/pom.xml
+++ b/parser/pom.xml
@@ -4,7 +4,6 @@
     <groupId>org.opencypher</groupId>
     <artifactId>front-end-parent</artifactId>
     <version>1.0.0-SNAPSHOT</version>
-    <relativePath>../</relativePath>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>
@@ -35,6 +34,15 @@
 
   <build>
     <plugins>
+      <plugin>
+        <groupId>net.alchim31.maven</groupId>
+        <artifactId>scala-maven-plugin</artifactId>
+        <configuration>
+          <args combine.children="append">
+            <arg>-language:postfixOps</arg>
+          </args>
+        </configuration>
+      </plugin>
       <plugin>
         <groupId>org.scalastyle</groupId>
         <artifactId>scalastyle-maven-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,8 @@
     <scala.binary.version>2.11</scala.binary.version>
     <scala.target.vm>1.8</scala.target.vm>
     <scala.java9.arg/>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
   </properties>
@@ -108,6 +110,9 @@
               <arg>-Xlint</arg>
               <arg>-target:jvm-${scala.target.vm}</arg>
               <arg>${scala.java9.arg}</arg>
+              <arg>-feature</arg>
+              <arg>-deprecation</arg>
+              <arg>-unchecked</arg>
             </args>
             <jvmArgs>
               <jvmArg>-Xms64m</jvmArg>
@@ -177,8 +182,16 @@
             </execution>
           </executions>
         </plugin>
-
       </plugins>
+      <pluginManagement>
+        <plugins>
+          <plugin>
+            <groupId>org.scalastyle</groupId>
+            <artifactId>scalastyle-maven-plugin</artifactId>
+            <version>1.0.0</version>
+          </plugin>
+        </plugins>
+      </pluginManagement>
   </build>
 
   <profiles>

--- a/rewriting/pom.xml
+++ b/rewriting/pom.xml
@@ -4,7 +4,6 @@
     <groupId>org.opencypher</groupId>
     <artifactId>front-end-parent</artifactId>
     <version>1.0.0-SNAPSHOT</version>
-    <relativePath>../</relativePath>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>
@@ -35,6 +34,16 @@
 
   <build>
     <plugins>
+      <plugin>
+        <groupId>net.alchim31.maven</groupId>
+        <artifactId>scala-maven-plugin</artifactId>
+        <configuration>
+          <args combine.children="append">
+            <arg>-language:implicitConversions</arg>
+            <arg>-language:reflectiveCalls</arg>
+          </args>
+        </configuration>
+      </plugin>
       <plugin>
         <groupId>org.scalastyle</groupId>
         <artifactId>scalastyle-maven-plugin</artifactId>

--- a/rewriting/src/test/scala/org/opencypher/v9_0/rewriting/InlineProjectionsTest.scala
+++ b/rewriting/src/test/scala/org/opencypher/v9_0/rewriting/InlineProjectionsTest.scala
@@ -286,12 +286,12 @@ class InlineProjectionsTest extends CypherFunSuite with AstRewritingTestSupport 
   }
 
   test("should refuse to inline queries containing update clauses by throwing CantHandleQueryException") {
-    evaluating {
+    an [InternalException] should be thrownBy {
       projectionInlinedAst(
         """CREATE (n)
           |RETURN n
         """.stripMargin)
-    } should produce[InternalException]
+    }
   }
 
   test("MATCH (n) WITH n.prop AS x WITH x LIMIT 10 RETURN x") {

--- a/rewriting/src/test/scala/org/opencypher/v9_0/rewriting/NormalizeWithClausesTest.scala
+++ b/rewriting/src/test/scala/org/opencypher/v9_0/rewriting/NormalizeWithClausesTest.scala
@@ -584,7 +584,7 @@ class NormalizeWithClausesTest extends CypherFunSuite with RewriteTest with AstC
   }
 
   test("match (n) with n as n order by max(n) return n") {
-    evaluating { rewriting("match (n) with n as n order by max(n) return n") } should produce[SyntaxException]
+    a [SyntaxException] should be thrownBy { rewriting("match (n) with n as n order by max(n) return n") }
   }
 
   protected override def assertRewrite(originalQuery: String, expectedQuery: String) {

--- a/util/pom.xml
+++ b/util/pom.xml
@@ -4,7 +4,6 @@
     <groupId>org.opencypher</groupId>
     <artifactId>front-end-parent</artifactId>
     <version>1.0.0-SNAPSHOT</version>
-    <relativePath>../</relativePath>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>
@@ -36,6 +35,17 @@
 
   <build>
     <plugins>
+      <plugin>
+        <groupId>net.alchim31.maven</groupId>
+        <artifactId>scala-maven-plugin</artifactId>
+        <configuration>
+          <args combine.children="append">
+            <arg>-language:implicitConversions</arg>
+            <arg>-language:existentials</arg>
+            <arg>-language:postfixOps</arg>
+          </args>
+        </configuration>
+      </plugin>
       <plugin>
         <groupId>org.scalastyle</groupId>
         <artifactId>scalastyle-maven-plugin</artifactId>


### PR DESCRIPTION
There remains only one which I do not fully understand.
It is relevant to this compiler bug: https://github.com/scala/bug/issues/4440

The rest has been fixed, by:

 - fixing build encoding
 - explicitly setting scalac flags
 - specifying missing artefact versions
 - rewriting exception assertions
 - replacing deprecated data structures